### PR TITLE
Add immutability

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,8 @@ config
 
 ## API
 
-All methods are chainable (unless otherwise stated), but not immutable. They
-work on a single instance. This is subject to change, so I wouldn't rely on it
-too much.
+Methods are designed to build out configs in a chain. All chainable methods
+return a copy (operations are immutable).
 
 ### Config
 
@@ -300,7 +299,9 @@ branches(branches: Branches) => Job
 
 The branch filter config to apply to this job. Note that this will apply at the
 workflow level, not at the job level. [See CircleCI Docs](https://circleci.com/docs/2.0/configuration-reference/#branches-1).
-This is a big reason that immutability might be added (so branches can be set inside different workflows).
+You can take advantage of immutability by settings branches on a job as you pass
+it in to the workflow. This was, you have one `Job`, and can set branches
+differently per-workflow.
 
 **Params**
 

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -97,12 +97,11 @@ describe('config', () => {
         command: 'ansible-playbook site.yml -i production',
       });
 
-    const config = new Config();
     const buildDeploy = new Workflow('build-deploy')
       .job(build)
       .job(deployStage, [build], stagingBranch)
       .job(deployProd, [build], masterBranch);
-    config.workflow(buildDeploy);
+    const config = new Config().workflow(buildDeploy);
 
     return config;
   }

--- a/__tests__/job.js
+++ b/__tests__/job.js
@@ -49,4 +49,11 @@ describe('Job', () => {
 
     expect(job.compose()).toMatchSnapshot();
   });
+
+  it('can be updated immutably', () => {
+    const jobOne = new Job('test-job');
+    const jobTwo = jobOne.progressiveRestoreCache('v1-this-is-a-test');
+
+    expect(jobOne).not.toEqual(jobTwo);
+  });
 });

--- a/__tests__/workflow.js
+++ b/__tests__/workflow.js
@@ -25,8 +25,7 @@ describe('Workflow', () => {
   it('can take triggers', () => {
     const branches = new Branches().only('test-branch');
 
-    const w = new Workflow('test-workflow');
-    w.schedule('* * * * *', branches);
+    const w = new Workflow('test-workflow').schedule('* * * * *', branches);
 
     expect(w.compose()).toMatchSnapshot();
   });

--- a/src/branches.js
+++ b/src/branches.js
@@ -12,8 +12,8 @@ export default class Branches {
     const item = new this.constructor();
     item.hasOnly = this.hasOnly;
     item.hasIgnore = this.hasIgnore;
-    item.onlyBranches = this.onlyBranches;
-    item.ignoreBranches = this.ignoreBranches;
+    item.onlyBranches = [...this.onlyBranches];
+    item.ignoreBranches = [...this.ignoreBranches];
 
     return item;
   }

--- a/src/branches.js
+++ b/src/branches.js
@@ -8,32 +8,44 @@ export default class Branches {
   onlyBranches: Array<string> = [];
   ignoreBranches: Array<string> = [];
 
+  clone() {
+    const item = new this.constructor();
+    item.hasOnly = this.hasOnly;
+    item.hasIgnore = this.hasIgnore;
+    item.onlyBranches = this.onlyBranches;
+    item.ignoreBranches = this.ignoreBranches;
+
+    return item;
+  }
+
   ignore(...branch: Array<string>) {
-    if (!this.hasWarned && this.hasOnly) {
+    const item = this.clone();
+    if (!item.hasWarned && item.hasOnly) {
       console.log(
         '[Warn] Adding `ignore` branches will result in `only` branches being ignored',
       );
-      this.hasWarned = true;
+      item.hasWarned = true;
     }
 
-    this.hasIgnore = true;
-    this.ignoreBranches.push(...branch);
+    item.hasIgnore = true;
+    item.ignoreBranches.push(...branch);
 
-    return this;
+    return item;
   }
 
   only(...branch: Array<string>) {
-    if (!this.hasWarned && this.hasIgnore) {
+    const item = this.clone();
+    if (!item.hasWarned && item.hasIgnore) {
       console.log(
         '[Warn] Adding `ignore` branches will result in `only` branches being ignored',
       );
-      this.hasWarned = true;
+      item.hasWarned = true;
     }
 
-    this.hasOnly = true;
-    this.onlyBranches.push(...branch);
+    item.hasOnly = true;
+    item.onlyBranches.push(...branch);
 
-    return this;
+    return item;
   }
 
   compose() {

--- a/src/executors/docker.js
+++ b/src/executors/docker.js
@@ -16,46 +16,61 @@ class Image {
     this.parent = parent;
   }
 
-  auth(auth: Auth) {
-    this.data.auth = auth;
+  clone() {
+    const clone = new this.constructor(this.data.image, this.parent);
+    clone.data = this.data;
+    clone.parent = this.parent;
 
-    return this;
+    return clone;
+  }
+
+  auth(auth: Auth) {
+    const clone = this.clone();
+    clone.data.auth = auth;
+
+    return clone;
   }
 
   awsAuth(awsAuth: AwsAuth) {
-    this.data.aws_auth = awsAuth;
+    const clone = this.clone();
+    clone.data.aws_auth = awsAuth;
 
-    return this;
+    return clone;
   }
 
   command(...command: Array<string>) {
-    this.data.command = command;
+    const clone = this.clone();
+    clone.data.command = command;
 
-    return this;
+    return clone;
   }
 
   entrypoint(...entrypoint: Array<string>) {
-    this.data.entrypoint = entrypoint;
+    const clone = this.clone();
+    clone.data.entrypoint = entrypoint;
 
-    return this;
+    return clone;
   }
 
   environment(env: { [string]: string }) {
-    this.data.environment = env;
+    const clone = this.clone();
+    clone.data.environment = env;
 
-    return this;
+    return clone;
   }
 
   name(name: string) {
-    this.data.name = name;
+    const clone = this.clone();
+    clone.data.name = name;
 
-    return this;
+    return clone;
   }
 
   user(user: string) {
-    this.data.user = user;
+    const clone = this.clone();
+    clone.data.user = user;
 
-    return this;
+    return clone;
   }
 
   compose() {
@@ -63,8 +78,9 @@ class Image {
   }
 
   done() {
-    this.parent.images.push(this);
-    return this.parent;
+    const clone = this.clone();
+    clone.parent.images.push(clone);
+    return clone.parent;
   }
 }
 
@@ -77,8 +93,15 @@ export default class Docker implements Executor {
     }
   }
 
+  clone() {
+    const clone = new this.constructor();
+    clone.images = [...this.images];
+    return clone;
+  }
+
   image(image: string) {
-    return new Image(image, this);
+    const clone = this.clone();
+    return new Image(image, clone);
   }
 
   compose(): { docker: Array<ImageData> } {

--- a/src/executors/docker.js
+++ b/src/executors/docker.js
@@ -18,7 +18,7 @@ class Image {
 
   clone() {
     const clone = new this.constructor(this.data.image, this.parent);
-    clone.data = this.data;
+    clone.data = { ...this.data };
     clone.parent = this.parent;
 
     return clone;

--- a/src/executors/machine.js
+++ b/src/executors/machine.js
@@ -13,18 +13,32 @@ export default class Machine implements Executor {
     this.state.enabled = enabled;
   }
 
+  clone() {
+    const clone = new this.constructor(this.state.enabled);
+    clone.state = {
+      ...this.state,
+    };
+
+    return clone;
+  }
+
   enabled(enabled: boolean) {
-    this.state.enabled = enabled;
-    return this;
+    const clone = this.clone();
+    clone.state.enabled = enabled;
+    return clone;
   }
 
   image(image: string) {
-    this.state.image = image;
-    return this;
+    const clone = this.clone();
+    clone.state.image = image;
+    return clone;
   }
 
   dockerLayerCaching(enabled: boolean) {
-    this.state.docker_layer_caching = enabled;
+    const clone = this.clone();
+    clone.state.docker_layer_caching = enabled;
+
+    return clone;
   }
 
   compose() {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ export default class Config {
   clone() {
     const item = new this.constructor();
     item.place = this.place;
-    item.workflows = this.workflows;
+    item.workflows = [...this.workflows];
 
     return item;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,16 +17,26 @@ export default class Config {
   place: string = path.resolve(Config.CONFIG_LOCATION);
   workflows: Array<Workflow> = [];
 
-  workflow(workflow: Workflow) {
-    this.workflows.push(workflow);
+  clone() {
+    const item = new this.constructor();
+    item.place = this.place;
+    item.workflows = this.workflows;
 
-    return this;
+    return item;
+  }
+
+  workflow(workflow: Workflow) {
+    const item = this.clone();
+    item.workflows.push(workflow);
+
+    return item;
   }
 
   location(directory: string = __dirname) {
-    this.place = path.resolve(directory, this.constructor.CONFIG_LOCATION);
+    const item = this.clone();
+    item.place = path.resolve(directory, item.constructor.CONFIG_LOCATION);
 
-    return this;
+    return item;
   }
 
   compose() {

--- a/src/job.js
+++ b/src/job.js
@@ -70,8 +70,8 @@ export default class Job {
   clone() {
     const clone = new this.constructor(this.name);
     clone.name = this.name;
-    clone.state = this.state;
-    clone.steps = this.steps;
+    clone.state = { ...this.state };
+    clone.steps = [...this.steps];
     clone.exec = this.exec;
     clone.branchConfig = this.branchConfig;
     return clone;

--- a/src/workflow.js
+++ b/src/workflow.js
@@ -28,8 +28,8 @@ export default class Workflow {
   clone() {
     const item = new this.constructor(this.name);
     item.name = this.name;
-    item.jobs = this.jobs;
-    item.schedules = this.schedules;
+    item.jobs = [...this.jobs];
+    item.schedules = [...this.schedules];
 
     return item;
   }

--- a/src/workflow.js
+++ b/src/workflow.js
@@ -25,6 +25,15 @@ export default class Workflow {
     this.name = name;
   }
 
+  clone() {
+    const item = new this.constructor(this.name);
+    item.name = this.name;
+    item.jobs = this.jobs;
+    item.schedules = this.schedules;
+
+    return item;
+  }
+
   job(
     job: Job,
     requires: ?Array<Job>,
@@ -45,13 +54,17 @@ export default class Workflow {
     if (filter) {
       config.filters = filter;
     }
-    this.jobs.push(config);
+    const item = this.clone();
+    item.jobs.push(config);
 
-    return this;
+    return item;
   }
 
   schedule(cron: string, filter: Branches) {
-    this.schedules.push({ cron, filters: filter.compose() });
+    const item = this.clone();
+    item.schedules.push({ cron, filters: filter.compose() });
+
+    return item;
   }
 
   compose() {


### PR DESCRIPTION
Dropping mutability allows for some cooler use-cases, like sharing the same job between workflows, with different filters, or partially defining similar jobs, and just changing the necessary parts.